### PR TITLE
Clean up types

### DIFF
--- a/const.py
+++ b/const.py
@@ -1,10 +1,12 @@
+from __future__ import annotations
+
 import sublime
 
 # @see https://github.com/latex-lsp/texlab/releases
 SERVER_VERSION = "v5.11.0"
 
 PLUGIN_NAME = "LSP-TexLab"
-SETTINGS_FILENAME = "{}.sublime-settings".format(PLUGIN_NAME)
+SETTINGS_FILENAME = f"{PLUGIN_NAME}.sublime-settings"
 
 # these platforms have an official pre-built texlab binary on GitHub
 PLATFORM_ARCH_TO_TARBALL = {
@@ -18,6 +20,6 @@ PLATFORM_ARCH_TO_TARBALL = {
 
 ARCH = sublime.arch()
 PLATFORM = sublime.platform()
-PLATFORM_ARCH = "{}_{}".format(PLATFORM, ARCH)
+PLATFORM_ARCH = f"{PLATFORM}_{ARCH}"
 ST_CHANNEL = sublime.channel()
 ST_VERSION = sublime.version()

--- a/lsp_texlab_auto_complete.py
+++ b/lsp_texlab_auto_complete.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sublime
 import sublime_plugin
 

--- a/lsp_texlab_build_system.py
+++ b/lsp_texlab_build_system.py
@@ -1,3 +1,5 @@
+from __future__ import annotations
+
 import sublime_plugin
 
 

--- a/plugin.py
+++ b/plugin.py
@@ -1,10 +1,17 @@
+from __future__ import annotations
+
 import os
 import shutil
+from typing import TypedDict, cast
 
 import sublime
-from LSP.plugin import AbstractPlugin, Request, register_plugin, unregister_plugin
-from LSP.plugin.core.registry import LspTextCommand
-from LSP.plugin.core.typing import Any, Dict, List, Tuple
+from LSP.plugin import (
+    AbstractPlugin,
+    LspTextCommand,
+    Request,
+    register_plugin,
+    unregister_plugin,
+)
 from LSP.plugin.core.views import (
     extract_variables,
     first_selection_region,
@@ -12,6 +19,8 @@ from LSP.plugin.core.views import (
     text_document_identifier,
     text_document_position_params,
 )
+from LSP.protocol import Position, TextDocumentIdentifier
+from typing_extensions import NotRequired
 
 from .const import (
     ARCH,
@@ -30,6 +39,11 @@ from .server import (
 from .tarball import decompress, download
 
 
+class TextDocumentBuildParams(TypedDict):
+    textDocument: TextDocumentIdentifier
+    position: NotRequired[Position]
+
+
 def plugin_loaded() -> None:
     register_plugin(LspTexLabPlugin)
 
@@ -44,14 +58,14 @@ class LspTexLabPlugin(AbstractPlugin):
         return PLUGIN_NAME
 
     @classmethod
-    def configuration(cls) -> Tuple[sublime.Settings, str]:
+    def configuration(cls) -> tuple[sublime.Settings, str]:
         name = cls.name()
-        basename = "{}.sublime-settings".format(name)
-        filepath = "Packages/{}/{}".format(name, basename)
+        basename = f"{name}.sublime-settings"
+        filepath = f"Packages/{name}/{basename}"
         return sublime.load_settings(basename), filepath
 
     @classmethod
-    def additional_variables(cls) -> Dict[str, str]:
+    def additional_variables(cls) -> dict[str, str]:
         return {
             "texlab_bin": get_default_server_bin_path()
             if PLATFORM_ARCH in PLATFORM_ARCH_TO_TARBALL
@@ -60,7 +74,7 @@ class LspTexLabPlugin(AbstractPlugin):
 
     @classmethod
     def needs_update_or_installation(cls) -> bool:
-        command = cls.configuration()[0].get("command")  # type: List[str]
+        command = cast(list[str], cls.configuration()[0].get("command"))
         server_bin = command[0]
 
         # only auto manage platforms which the official server supports
@@ -150,7 +164,7 @@ class LspTexlabBuildCommand(LspTextCommand):
         session = self.session_by_name(PLUGIN_NAME)
         if not session:
             return
-        params = {"textDocument": text_document_identifier(self.view)}
+        params: TextDocumentBuildParams = {"textDocument": text_document_identifier(self.view)}
         region = first_selection_region(self.view)
         if region is not None:
             params["position"] = offset_to_point(self.view, region.b).to_lsp()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,4 +34,8 @@ exclude = '''
 '''
 
 [tool.pyright]
-pythonVersion = '3.11'
+pythonVersion = '3.8'
+
+[tool.ruff]
+target-version = 'py38'
+

--- a/server.py
+++ b/server.py
@@ -1,8 +1,9 @@
+from __future__ import annotations
+
 import os
 from functools import lru_cache
 
 import sublime
-from LSP.plugin.core.typing import Optional
 
 from .const import (
     ARCH,
@@ -14,7 +15,7 @@ from .const import (
 )
 
 
-@lru_cache()
+@lru_cache
 def get_plugin_storage_dir() -> str:
     """Gets this plugin's storage dir."""
 
@@ -23,8 +24,8 @@ def get_plugin_storage_dir() -> str:
     )
 
 
-@lru_cache()
-def get_server_download_url(version: str, platform: str, arch: str) -> Optional[str]:
+@lru_cache
+def get_server_download_url(version: str, platform: str, arch: str) -> str | None:
     """
     Gets the LSP server download URL.
 
@@ -35,7 +36,7 @@ def get_server_download_url(version: str, platform: str, arch: str) -> Optional[
 
     settings = sublime.load_settings(SETTINGS_FILENAME)
     url = settings.get("lsp_server_download_url", "")  # type: str
-    tarball = PLATFORM_ARCH_TO_TARBALL.get("{}_{}".format(platform, arch), "")
+    tarball = PLATFORM_ARCH_TO_TARBALL.get(f"{platform}_{arch}", "")
 
     if not (url and tarball):
         return None
@@ -49,16 +50,16 @@ def get_server_download_url(version: str, platform: str, arch: str) -> Optional[
     )
 
 
-@lru_cache()
+@lru_cache
 def get_server_dir() -> str:
     """Gets the server directory."""
 
-    server_dir = "{}-{}~{}".format(PLATFORM, ARCH, SERVER_VERSION)
+    server_dir = f"{PLATFORM}-{ARCH}~{SERVER_VERSION}"
 
     return os.path.join(get_plugin_storage_dir(), server_dir)
 
 
-@lru_cache()
+@lru_cache
 def get_default_server_bin_path() -> str:
     """Gets the default LSP server binary path."""
     return os.path.join(

--- a/tarball.py
+++ b/tarball.py
@@ -1,13 +1,14 @@
+from __future__ import annotations
+
 import gzip
 import os
 import tarfile
 import urllib.request
 import zipfile
+from collections.abc import Iterable
 
-from LSP.plugin.core.typing import Iterable, Optional
 
-
-def decompress(tarball: str, dst_dir: Optional[str] = None) -> None:
+def decompress(tarball: str, dst_dir: str | None = None) -> None:
     """
     Decompress the tarball.
 
@@ -18,7 +19,7 @@ def decompress(tarball: str, dst_dir: Optional[str] = None) -> None:
     def tar_safe_extract(
         tar: tarfile.TarFile,
         path: str = ".",
-        members: Optional[Iterable[tarfile.TarInfo]] = None,
+        members: Iterable[tarfile.TarInfo] | None = None,
     ) -> None:
         def is_within_directory(directory: str, target: str) -> bool:
             abs_directory = os.path.abspath(directory)


### PR DESCRIPTION
- Import types from `types` rather than LSP
- Use more modern type syntax where possible
- Use f-string formatting
- Address breaking change happening in next LSP release.