### PR TITLE
refactor: add ruff rules for sorting imports

### DIFF
--- a/plugin.py
+++ b/plugin.py
@@ -1,42 +1,36 @@
 from __future__ import annotations
 
+from .const import ARCH
+from .const import PLATFORM
+from .const import PLATFORM_ARCH
+from .const import PLATFORM_ARCH_TO_TARBALL
+from .const import PLUGIN_NAME
+from .const import SERVER_VERSION
+from .server import get_default_server_bin_path
+from .server import get_plugin_storage_dir
+from .server import get_server_dir
+from .server import get_server_download_url
+from .tarball import decompress
+from .tarball import download
+from LSP.plugin import AbstractPlugin
+from LSP.plugin import LspTextCommand
+from LSP.plugin import register_plugin
+from LSP.plugin import Request
+from LSP.plugin import unregister_plugin
+from LSP.plugin.core.views import extract_variables
+from LSP.plugin.core.views import first_selection_region
+from LSP.plugin.core.views import offset_to_point
+from LSP.plugin.core.views import text_document_identifier
+from LSP.plugin.core.views import text_document_position_params
+from LSP.protocol import Position
+from LSP.protocol import TextDocumentIdentifier
+from typing import Any
+from typing import cast
+from typing import TypedDict
+from typing_extensions import NotRequired
 import os
 import shutil
-from typing import Any, TypedDict, cast
-
 import sublime
-from LSP.plugin import (
-    AbstractPlugin,
-    LspTextCommand,
-    Request,
-    register_plugin,
-    unregister_plugin,
-)
-from LSP.plugin.core.views import (
-    extract_variables,
-    first_selection_region,
-    offset_to_point,
-    text_document_identifier,
-    text_document_position_params,
-)
-from LSP.protocol import Position, TextDocumentIdentifier
-from typing_extensions import NotRequired
-
-from .const import (
-    ARCH,
-    PLATFORM,
-    PLATFORM_ARCH,
-    PLATFORM_ARCH_TO_TARBALL,
-    PLUGIN_NAME,
-    SERVER_VERSION,
-)
-from .server import (
-    get_default_server_bin_path,
-    get_plugin_storage_dir,
-    get_server_dir,
-    get_server_download_url,
-)
-from .tarball import decompress, download
 
 
 class TextDocumentBuildParams(TypedDict):

--- a/plugin.py
+++ b/plugin.py
@@ -1,36 +1,24 @@
 from __future__ import annotations
 
-from .const import ARCH
-from .const import PLATFORM
-from .const import PLATFORM_ARCH
-from .const import PLATFORM_ARCH_TO_TARBALL
-from .const import PLUGIN_NAME
-from .const import SERVER_VERSION
-from .server import get_default_server_bin_path
-from .server import get_plugin_storage_dir
-from .server import get_server_dir
-from .server import get_server_download_url
-from .tarball import decompress
-from .tarball import download
-from LSP.plugin import AbstractPlugin
-from LSP.plugin import LspTextCommand
-from LSP.plugin import register_plugin
-from LSP.plugin import Request
-from LSP.plugin import unregister_plugin
-from LSP.plugin.core.views import extract_variables
-from LSP.plugin.core.views import first_selection_region
-from LSP.plugin.core.views import offset_to_point
-from LSP.plugin.core.views import text_document_identifier
-from LSP.plugin.core.views import text_document_position_params
-from LSP.protocol import Position
-from LSP.protocol import TextDocumentIdentifier
-from typing import Any
-from typing import cast
-from typing import TypedDict
-from typing_extensions import NotRequired
 import os
 import shutil
+from typing import Any, TypedDict, cast
+
 import sublime
+from LSP.plugin import AbstractPlugin, LspTextCommand, Request, register_plugin, unregister_plugin
+from LSP.plugin.core.views import (
+    extract_variables,
+    first_selection_region,
+    offset_to_point,
+    text_document_identifier,
+    text_document_position_params,
+)
+from LSP.protocol import Position, TextDocumentIdentifier
+from typing_extensions import NotRequired
+
+from .const import ARCH, PLATFORM, PLATFORM_ARCH, PLATFORM_ARCH_TO_TARBALL, PLUGIN_NAME, SERVER_VERSION
+from .server import get_default_server_bin_path, get_plugin_storage_dir, get_server_dir, get_server_download_url
+from .tarball import decompress, download
 
 
 class TextDocumentBuildParams(TypedDict):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,7 @@ preview = true
 select = ["F401", "I"]
 
 [tool.ruff.lint.isort]
-case-sensitive = false
-force-single-line = true
-from-first = true
-no-sections = true
+case-sensitive = true
+combine-as-imports = true
 order-by-type = false
 required-imports = ["from __future__ import annotations"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,41 +1,19 @@
-[tool.isort]
-line_length = 120
-profile = 'black'
-py_version=38
-skip_glob = [
-  ".venv/**",
-  "br-*/**",
-  "branch-*/**",
-  "libs/**",
-  "resources/**",
-  "stubs/**",
-  "typings/**",
-  "vendor/**",
-  "venv/**",
-]
-
-[tool.pycln]
-all = true
-exclude = '(\.git|\.?venv|\.mypy_cache|br-.*|branch-.*|libs|stubs|typings)/'
-
-[tool.black]
-line-length = 120
-target-version = ['py33']
-exclude = '''
-/(
-  \.git |
-  language-server |
-  plugin/libs |
-  resources |
-  stubs |
-  typings |
-  _resources
-)/
-'''
-
 [tool.pyright]
 pythonVersion = '3.8'
 
 [tool.ruff]
 target-version = 'py38'
+line-length = 120
 
+[tool.ruff.lint]
+# Enable preview rules.
+preview = true
+select = ["F401", "I"]
+
+[tool.ruff.lint.isort]
+case-sensitive = false
+force-single-line = true
+from-first = true
+no-sections = true
+order-by-type = false
+required-imports = ["from __future__ import annotations"]

--- a/server.py
+++ b/server.py
@@ -1,18 +1,14 @@
 from __future__ import annotations
 
-import os
+from .const import ARCH
+from .const import PLATFORM
+from .const import PLATFORM_ARCH_TO_TARBALL
+from .const import PLUGIN_NAME
+from .const import SERVER_VERSION
+from .const import SETTINGS_FILENAME
 from functools import lru_cache
-
+import os
 import sublime
-
-from .const import (
-    ARCH,
-    PLATFORM,
-    PLATFORM_ARCH_TO_TARBALL,
-    PLUGIN_NAME,
-    SERVER_VERSION,
-    SETTINGS_FILENAME,
-)
 
 
 @lru_cache

--- a/server.py
+++ b/server.py
@@ -1,14 +1,11 @@
 from __future__ import annotations
 
-from .const import ARCH
-from .const import PLATFORM
-from .const import PLATFORM_ARCH_TO_TARBALL
-from .const import PLUGIN_NAME
-from .const import SERVER_VERSION
-from .const import SETTINGS_FILENAME
-from functools import lru_cache
 import os
+from functools import lru_cache
+
 import sublime
+
+from .const import ARCH, PLATFORM, PLATFORM_ARCH_TO_TARBALL, PLUGIN_NAME, SERVER_VERSION, SETTINGS_FILENAME
 
 
 @lru_cache

--- a/tarball.py
+++ b/tarball.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
-from collections.abc import Iterable
 import gzip
 import os
 import tarfile
 import urllib.request
 import zipfile
+from collections.abc import Iterable
 
 
 def decompress(tarball: str, dst_dir: str | None = None) -> None:

--- a/tarball.py
+++ b/tarball.py
@@ -1,11 +1,11 @@
 from __future__ import annotations
 
+from collections.abc import Iterable
 import gzip
 import os
 import tarfile
 import urllib.request
 import zipfile
-from collections.abc import Iterable
 
 
 def decompress(tarball: str, dst_dir: str | None = None) -> None:


### PR DESCRIPTION
This is a semi-automatically created PR that adds ruff configuration for imports formatting.

It matches configuration included in the LSP package with the intention of consolidating import style across all LSP packages.

If you have strong preference to a different style, please keep the configuration but update it to your liking so that anyone working on the package does not have to guess the correct style to use. See [ruff isort settings](https://docs.astral.sh/ruff/settings/#lintisort).

(Since this PR was created semi-automatically, it might require some changes before being considered ready.)